### PR TITLE
Added ability to load emoncms from different folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Vagrant
+/.vagrant
+
+# Configuration
+/settings.yml

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 ## Emoncms Vagrant development box config 
 
+Copy `settings.yml.sample` to `settings.yml` and modify the reference to where you have emoncms checked out.
+
+Then run `vagrant up` and voila!
+
 * Accessible on localhost:8080 on the host machine
 * Included xdebug for debugging
 * Based on Ubuntu 14.04 with php 5.6

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,11 +1,22 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+require 'yaml'
+
 Vagrant.configure(2) do |config|
 
     config.vm.box = "bento/ubuntu-14.04"
     config.vm.network "forwarded_port", guest: 80, host: 8080
-    config.vm.synced_folder ".", "/var/www/html", :owner => "www-data", :group => "www-data"
+
+    settingsYml = File.expand_path("../settings.yml", __FILE__)
+
+    if File.exists? settingsYml then
+        settings = YAML::load(File.read(settingsYml))
+    else
+
+    end
+
+    config.vm.synced_folder settings["emoncms_source"], "/var/www/html", :owner => "www-data", :group => "www-data"
 
     config.vm.provider "virtualbox" do |vb|
         vb.name = "emoncms"

--- a/settings.yml.sample
+++ b/settings.yml.sample
@@ -1,0 +1,1 @@
+emoncms: '/path/to/emoncms' # This can be a relative path too


### PR DESCRIPTION
This change will enable you to reference `emoncms` properly so it can be in a completely different folder. 

TODO:
- Add error when `settings.yml` not found
